### PR TITLE
新增两个lua

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -53,6 +53,8 @@ switches:
 engine:
   processors:
     - lua_processor@select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder
@@ -294,7 +296,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -53,6 +53,8 @@ switches:
 engine:
   processors:
     - lua_processor@*select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder
@@ -297,7 +299,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -53,6 +53,8 @@ switches:
 engine:
   processors:
     - lua_processor@select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder
@@ -294,7 +296,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -53,6 +53,8 @@ switches:
 engine:
   processors:
     - lua_processor@select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder
@@ -298,7 +300,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -53,6 +53,8 @@ switches:
 engine:
   processors:
     - lua_processor@select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder
@@ -298,7 +300,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -53,6 +53,8 @@ switches:
 engine:
   processors:
     - lua_processor@select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder
@@ -296,7 +298,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的

--- a/lua/quick_symbol_text.lua
+++ b/lua/quick_symbol_text.lua
@@ -1,0 +1,159 @@
+-- 欢迎使用带声调的拼音词库
+-- @amzxyz
+-- https://github.com/amzxyz/rime_feisheng
+-- https://github.com/amzxyz/rime_wanxiang_pinyin
+-- 本lua通过定义一个不直接上屏的引导符号搭配26字母实现快速符号输入，并在双击''上屏上一次的符号，双击;;重复上屏上次的汉字和字母
+-- 使用方式加入到函数 - lua_processor@*quick_symbol_text 下面
+-- 方案文件配置,
+-- recognizer/patterns/quick_symbol: "^'.*$"
+-- recognizer/patterns/quick_text: "^;.*$"
+-- 定义符号映射表
+local mapping = {
+    q = "“",
+    w = "？",
+    e = "（",
+    r = "）",
+    t = "~",
+    y = "·",
+    u = "『",
+    i = "』",
+    o = "〖",
+    p = "〗",
+    a = "！",
+    s = "……",
+    d = "、",
+    f = "“",
+    g = "”",
+    h = "‘",
+    j = "’",
+    k = "——",
+    l = "%",
+    z = "。”",
+    x = "？”",
+    c = "！”",
+    v = "【",
+    b = "】",
+    n = "《",
+    m = "》"
+}
+
+-- 记录上次上屏的内容
+local last_commit_symbol = ""  -- 存储符号的上屏历史
+local last_commit_text = ""    -- 存储文本（汉字/字母）的上屏历史
+
+-- 判断字符是否为符号，包括半角和全角符号
+local function is_symbol(char)
+    -- 检测半角符号范围
+    if string.match(char, "[!@#$%%%^&*()%-_=+%[%]{}\\|;:'\",.<>/?`~]") then
+        return true
+    end
+    -- 检测全角符号范围
+    if string.match(char, "[！＠＃＄％＾＆＊（）＿＋－＝［］｛｝；：‘’“”、，。／？｀～]") then
+        return true
+    end
+    return false
+end
+
+-- 判断上屏内容是符号还是文本（汉字/字母）
+local function classify_commit_text(commit_text)
+    -- 如果上屏内容中全是符号，则认为是符号
+    if commit_text and #commit_text > 0 then
+        for i = 1, #commit_text do
+            local char = string.sub(commit_text, i, i)
+            if not is_symbol(char) then
+                return "text"  -- 上屏内容包含非符号字符，认为是文本
+            end
+        end
+        return "symbol"  -- 上屏内容全是符号
+    end
+    return "unknown"
+end
+
+-- 初始化符号输入的状态
+local function init(env)
+    -- 读取 RIME 配置文件中的引导符号模式
+    local config = env.engine.schema.config
+
+    -- 动态读取符号和文本重复的引导模式
+    local quick_symbol_pattern = config:get_string("recognizer/patterns/quick_symbol") or "^'.*$"
+    local quick_text_pattern = config:get_string("recognizer/patterns/quick_text") or "^;.*$"
+
+    -- 提取配置值中的第二个字符作为引导符
+    local quick_symbol = string.sub(quick_symbol_pattern, 2, 2) or "'"
+    local quick_text = string.sub(quick_text_pattern, 2, 2) or ";"
+    
+    -- 生成单引导符和双引导符模式
+    env.single_symbol_pattern = "^" .. quick_symbol .. "([a-zA-Z])$"
+    env.double_symbol_pattern_symbol = "^" .. quick_symbol .. quick_symbol .. "$"
+    env.double_symbol_pattern_text = "^" .. quick_text .. quick_text .. "$"
+
+    -- 捕获上屏事件，分类存储符号和文本
+    env.engine.context.commit_notifier:connect(function(ctx)
+        local commit_text = ctx:get_commit_text()
+
+        -- 通过分类判断是符号还是文本
+        local classification = classify_commit_text(commit_text)
+        if classification == "symbol" then
+            last_commit_symbol = commit_text  -- 保存符号到 last_commit_symbol
+        elseif classification == "text" then
+            last_commit_text = commit_text  -- 保存文本到 last_commit_text
+        end
+    end)
+end
+
+-- 捕获符号键盘事件并记录符号
+local function capture_symbol_key(key_event)
+    -- 获取按键字符表示
+    local keychar = key_event:repr()
+
+    -- 判断该字符是否为符号（半角或全角）
+    if is_symbol(keychar) then
+        return keychar  -- 返回符号字符
+    end
+
+    return nil
+end
+
+-- 处理符号和文本的重复上屏逻辑
+local function processor(key_event, env)
+    local engine = env.engine
+    local context = engine.context
+    local input = context.input  -- 当前输入的字符串
+
+    -- 1. 检查是否输入的编码为双引导符 ;;，用于汉字或字母重复上屏
+    if string.match(input, env.double_symbol_pattern_text) then
+        if last_commit_text ~= "" then
+            engine:commit_text(last_commit_text)  -- 上屏上次的汉字或文本
+            context:clear()  -- 清空输入
+            return 1  -- 捕获事件，处理完成
+        end
+    end
+
+    -- 2. 检查是否输入的编码为双引导符 ''，用于符号重复上屏
+    if string.match(input, env.double_symbol_pattern_symbol) then
+        if last_commit_symbol ~= "" then
+            engine:commit_text(last_commit_symbol)  -- 上屏上次的符号
+            context:clear()  -- 清空输入
+            return 1  -- 捕获事件，处理完成
+        end
+    end
+
+    -- 3. 检查当前输入是否匹配单引导符符号模式 'q、'w 等
+    local match = string.match(input, env.single_symbol_pattern)
+    if match then
+        local symbol = mapping[match]  -- 获取匹配的符号
+        if symbol then
+            -- 将符号直接上屏并保存到符号历史
+            engine:commit_text(symbol)
+            last_commit_symbol = symbol  -- 保存符号到 last_commit_symbol
+            context:clear()  -- 清空输入
+            return 1  -- 捕获事件，处理完成
+        end
+    end
+
+    return 2  -- 未处理事件，继续传播
+end
+
+-- 导出到 RIME
+return { init = init, func = processor }
+

--- a/lua/userdb_sync_delete.lua
+++ b/lua/userdb_sync_delete.lua
@@ -1,0 +1,340 @@
+--欢迎使用带声调的词库:飞声词库
+--https://github.com/amzxyz/rime_feisheng
+--@amzxyz
+--引入方式: - lua_processor@*userdb_sync_delete
+--这个脚本通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条,同时删除rime目录下的*.userdb目录,之后手动执行重新部署以彻底删除由Ctrl+del删除的用户词
+--⚠️使用前先执行同步保存现有的用户词,再执行/del,等待提示完成清理多少条,即完成清理,之后重新部署一下刷新数据,最后执行同步才能加载回来清理后的用户词,这部分工作单靠lua无法完成
+-- 兼容linux windows ,有通知；安卓同文输入法测试通过,无通知
+-- 初始化函数
+function init(env)
+    log.info("用户词库清理程序初始化成功")
+    if not env.initialized then
+        env.initialized = true
+        env.os_type = detect_os_type()  -- 全局变量，存储系统类型
+        env.pending_directories = {}  -- 用于保存所有待处理的目录路径
+        env.total_deleted = 0  -- 记录删除的总条目数
+    end
+end
+
+-- 手动维护的操作系统检测模式表
+local os_detection_patterns = {
+    windows = { "weasel", "Weasel" },    -- Windows 的标识符列表
+    linux = { "fcitx%-rime" },           -- Linux 的标识符
+    macos = { "squirrel" },              -- macOS 的标识符
+    android = { "trime" }                -- android 的标识符
+}
+
+-- 定义全局函数 detect_os_type
+function detect_os_type()
+    local user_data_dir = rime_api.get_user_data_dir()
+    local yaml_path = user_data_dir .. "/installation.yaml"
+
+    -- 打开 installation.yaml 文件
+    local file, err = io.open(yaml_path, "r")
+    if not file then
+        log.error("无法打开 installation.yaml 文件: " .. tostring(err))
+        return "unknown"
+    end
+
+    -- 遍历文件内容并检测 distribution_code_name 字段
+    local os_type = "unknown"
+    for line in file:lines() do
+        local dist_name = line:match('^%s*distribution_code_name:%s*"?([%w%-]+)"?')
+        if dist_name then
+            -- 遍历 os_detection_patterns 表来匹配系统类型
+            for os, patterns in pairs(os_detection_patterns) do
+                for _, pattern in ipairs(patterns) do
+                    if dist_name:match(pattern) then
+                        os_type = os
+                        break
+                    end
+                end
+                if os_type ~= "unknown" then break end
+            end
+            break
+        end
+    end
+
+    file:close()  -- 关闭文件
+    log.info("检测到的操作系统类型为: " .. os_type)
+    return os_type
+end
+
+-- 检测并处理路径分隔符转换
+function convert_path_separator(path, os_type)
+    if os_type == "windows" then
+        path = path:gsub("\\\\", "\\")  -- 将双反斜杠替换为单反斜杠
+    end
+    return path
+end
+
+-- 从 installation.yaml 文件中获取 sync_dir 路径
+function get_sync_path_from_yaml(env)
+    local user_data_dir = rime_api.get_user_data_dir()
+    local yaml_path = user_data_dir .. "/installation.yaml"
+
+    -- 使用标准 Lua io.open 打开文件
+    local file, err = io.open(yaml_path, "r")
+    if not file then
+        log.error("无法打开 installation.yaml 文件: " .. tostring(err))
+        return nil, "无法打开 installation.yaml 文件"
+    end
+
+    -- 读取文件并提取 sync_dir 的值
+    local sync_dir = nil
+    for line in file:lines() do
+        local key, value = line:match('(sync_dir):%s*"?(.-)"?%s*$')
+        if key and value then
+            sync_dir = value:match("^%s*(.-)%s*$")
+            sync_dir = convert_path_separator(sync_dir, env.os_type)  -- 根据系统类型转换路径分隔符
+            sync_dir = sync_dir:gsub('%"', '')  -- 去掉路径中的引号
+            break
+        end
+    end
+
+    file:close()  -- 关闭文件
+
+    if sync_dir then
+        log.info("获取的 sync_dir 路径为: " .. sync_dir)
+        return sync_dir, nil
+    else
+        local default_sync_dir = user_data_dir .. "/sync"  -- 与 installation.yaml 同级的 sync 目录
+        log.info("未能从 installation.yaml 获取到 sync_dir，使用默认路径: " .. default_sync_dir)
+        return default_sync_dir, nil
+    end
+end
+
+
+
+-- 捕获输入并执行相应的操作
+function UserDictCleaner_process(key_event, env)
+    local engine = env.engine
+    local context = engine.context
+    local input = context.input
+
+    -- 检查是否输入 /del
+    if input == "/del" and env.initialized then
+        log.info("检测到 /del 输入，开始执行清理操作...")
+        env.total_deleted = 0  -- 重置计数器
+
+        local success, err = pcall(trigger_sync_cleanup, env)
+        if not success then
+            log.error("清理操作失败: " .. tostring(err))
+            send_user_notification(0, env)  -- 清理操作失败时发送0
+        else
+            log.info("清理操作完成。")
+            send_user_notification(env.total_deleted, env)
+        end
+
+        -- 清空输入内容，防止输入保留
+        context:clear()
+        return 1  -- 返回 1 表示已处理该事件
+    end
+
+    return 2  -- 返回 2 继续处理其它输入
+end
+
+-- 定义固定部分的ANSI编码
+local base_message = "\xD3\xC3\xBB\xA7\xB4\xCA\xB5\xE4\xB9\xB2\xC7\xE5\xC0\xED\x20" -- "用户词典共清理 "（注意结尾有一个空格）
+local end_message = "\x20\xD0\xD0\xCE\xDE\xD0\xA7\xB4\xCA\xCC\xF5" -- " 行无效词条"（前面带一个空格）
+
+-- 预定义数字0-9的ANSI编码表示
+local digit_to_ansi = {
+    ["0"] = "\x30", ["1"] = "\x31", ["2"] = "\x32", ["3"] = "\x33",
+    ["4"] = "\x34", ["5"] = "\x35", ["6"] = "\x36", ["7"] = "\x37",
+    ["8"] = "\x38", ["9"] = "\x39"
+}
+
+-- 生成ANSI编码的删除条目数量部分
+function encode_deleted_count_to_ansi(deleted_count)
+    local ansi_count = ""
+    for i = 1, #tostring(deleted_count) do
+        local digit = tostring(deleted_count):sub(i, i)
+        local encoded_digit = digit_to_ansi[digit] or ""
+        ansi_count = ansi_count .. encoded_digit
+    end
+    return ansi_count
+end
+
+-- 动态生成完整的ANSI消息（适用于Windows）
+function generate_ansi_message(deleted_count)
+    local encoded_count = encode_deleted_count_to_ansi(deleted_count)
+    return base_message .. encoded_count .. end_message
+end
+
+-- 动态生成UTF-8消息（适用于Linux）
+function generate_utf8_message(deleted_count)
+    return "用户词典共清理 " .. tostring(deleted_count) .. " 行无效词条"
+end
+
+-- 发送通知反馈函数，使用动态生成的消息
+function send_user_notification(deleted_count, env)
+    if env.os_type == "windows" then
+        local ansi_message = generate_ansi_message(deleted_count)
+        os.execute('msg * "' .. ansi_message .. '"')
+    elseif env.os_type == "linux" then
+        local utf8_message = generate_utf8_message(deleted_count)
+        os.execute('notify-send "' .. utf8_message .. '"')
+    elseif env.os_type == "macos" then
+        local utf8_message = generate_utf8_message(deleted_count)
+        os.execute('osascript -e \'display notification "' .. utf8_message .. '"\'')
+    elseif env.os_type == "android" then
+        local utf8_message = generate_utf8_message(deleted_count)
+        os.execute('notify "' .. utf8_message .. '"')
+    else
+        log.info("无法发送通知，未识别的操作系统")
+    end
+end
+
+-- 使用 os 执行不同的命令，列出文件
+function list_files(path, env)
+    local command = env.os_type == "windows" and ('dir "' .. path .. '" /b') or ('ls -1 "' .. path .. '"')
+    local handle = io.popen(command)
+    if not handle then
+        log.error("无法遍历路径: " .. path)
+        return nil, "无法遍历路径: " .. path
+    end
+
+    local files = {}
+    for file in handle:lines() do
+        table.insert(files, file)
+    end
+    handle:close()
+    return files, nil
+end
+
+-- 递归删除 installation.yaml 同级目录下的 .userdb 文件夹
+function delete_userdb_folders(env)
+    local user_data_dir = rime_api.get_user_data_dir()
+    local files, err = list_files(user_data_dir, env)
+
+    if not files then
+        log.error("无法列出文件夹")
+        return
+    end
+
+    -- 遍历文件夹，删除以 .userdb 结尾的文件夹
+    for _, file in ipairs(files) do
+        if file:match("%.userdb$") then
+            local full_path = user_data_dir .. "/" .. file
+            log.info("发现并删除 userdb 文件夹: " .. full_path)
+            if env.os_type == "windows" then
+                os.execute('rmdir /S /Q "' .. full_path .. '"')
+            else
+                os.execute('rm -rf "' .. full_path .. '"')
+            end
+            log.info("删除 userdb 文件夹完成: " .. full_path)
+        end
+    end
+end
+
+-- 收集目录的函数
+function collect_directories(path, env)
+    local directories, err = list_files(path, env)
+    if not directories then
+        log.error("收集目录失败: " .. tostring(err))
+        return
+    end
+
+    -- 将找到的所有目录添加到 pending_directories 列表
+    for _, dir in ipairs(directories) do
+        local full_path = path .. "/" .. dir
+        table.insert(env.pending_directories, full_path)
+    end
+end
+
+-- 处理所有已收集的目录
+function process_collected_directories(env)
+    while #env.pending_directories > 0 do
+        local directory = table.remove(env.pending_directories)
+        log.info("处理目录: " .. directory)
+
+        local files, err = list_files(directory, env)
+        if not files then
+            log.error("处理目录失败: " .. tostring(err))
+        else
+            for _, file in ipairs(files) do
+                if file:match("%.userdb%.txt$") then
+                    log.info("发现 userdb 文件: " .. directory .. "/" .. file)
+                    process_userdb_file(directory .. "/" .. file, env)
+                end
+            end
+        end
+    end
+end
+
+-- 处理 .userdb.txt 文件并删除 c < 0 条目的函数
+function process_userdb_file(file_path, env)
+    log.info("开始处理 userdb 文件: " .. file_path)
+
+    local file, err = io.open(file_path, "r")
+    if not file then
+        log.error("无法打开文件: " .. file_path .. " 错误: " .. tostring(err))
+        return
+    end
+
+    local temp_file_path = file_path .. ".tmp"
+    local temp_file = io.open(temp_file_path, "w")
+    if not temp_file then
+        log.error("无法创建临时文件: " .. temp_file_path .. " 错误: " .. tostring(err))
+        file:close()
+        return
+    end
+
+    local entries_deleted = false
+    local delete_count = 0
+    for line in file:lines() do
+        local c_value = line:match("c=(%-?%d+)")
+        if c_value then
+            c_value = tonumber(c_value)
+            if c_value > 0 then
+                temp_file:write(line .. "\n")
+            else
+                log.info("删除条目: " .. line:sub(1, 30) .. "...")
+                entries_deleted = true
+                delete_count = delete_count + 1
+            end
+        else
+            temp_file:write(line .. "\n")
+        end
+    end
+
+    file:close()
+    temp_file:close()
+
+    if entries_deleted then
+        log.info("已删除 " .. tostring(delete_count) .. " 个条目，替换原文件。")
+        os.remove(file_path)
+        os.rename(temp_file_path, file_path)
+        -- 更新总删除计数
+        env.total_deleted = env.total_deleted + delete_count
+    else
+        log.info("没有发现无效条目，跳过文件替换。")
+        os.remove(temp_file_path)
+    end
+end
+
+-- 触发清理操作
+function trigger_sync_cleanup(env)
+    local sync_path, err = get_sync_path_from_yaml(env)
+    if not sync_path then
+        log.error(err)
+        send_user_notification(0, env)
+        return
+    end
+
+    -- 收集所有子目录
+    collect_directories(sync_path, env)
+
+    -- 处理所有收集到的目录
+    process_collected_directories(env)
+
+    -- 删除 .userdb 文件夹
+    delete_userdb_folders(env)
+end
+
+-- 返回初始化和处理函数
+return {
+    init = init,
+    func = UserDictCleaner_process
+}

--- a/rime_frost.schema.yaml
+++ b/rime_frost.schema.yaml
@@ -43,6 +43,8 @@ switches:
 engine:
   processors:
     - lua_processor@select_character          # 以词定字
+    - lua_processor@*quick_symbol_text    #快符引导以及重复上屏
+    - lua_processor@*userdb_sync_delete   #通过输入 /del 触发,用于清理自定义同步目录下txt用户词典里被标记c<0的词条
     - ascii_composer
     - recognizer
     - key_binder

--- a/rime_frost.schema.yaml
+++ b/rime_frost.schema.yaml
@@ -400,7 +400,8 @@ recognizer:
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@*number_translator，数字金额大写
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@*lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
     calculator: "^V.*$"                 #计算器功能引导
-
+    quick_symbol: "^'.*$"  # 快符引导，例如输入'q 后自动上屏快速符号，双击''重复上屏符号
+    quick_text: "^;.*$"  # 双击;;重复上屏
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的


### PR DESCRIPTION
1、快符与重复上屏，'q之类扩展映射，''重复符号，;;重复汉字与字母;
2、用户词库清理命令输入/del触发，功能包括删除用户词同步路径下txt文件中c<=0的词条，同时删除rime目录下userdb文件夹，这将真实删除Ctrl +del删除的用户词，在这之前手动进行 1、先同步一次，2、执行指令，3、重新部署，4同步词库，有条件的朋友 1、3、4可以制作本地脚本来实现