### PR TITLE
修复：更正辅助码引导符配置名称

### DIFF
--- a/rime_frost.schema.yaml
+++ b/rime_frost.schema.yaml
@@ -402,7 +402,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的快捷键
 
 

--- a/rime_frost_double_pinyin.schema.yaml
+++ b/rime_frost_double_pinyin.schema.yaml
@@ -298,7 +298,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的
 
 

--- a/rime_frost_double_pinyin_abc.schema.yaml
+++ b/rime_frost_double_pinyin_abc.schema.yaml
@@ -301,7 +301,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的
 
 

--- a/rime_frost_double_pinyin_flypy.schema.yaml
+++ b/rime_frost_double_pinyin_flypy.schema.yaml
@@ -298,7 +298,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的
 
 

--- a/rime_frost_double_pinyin_mspy.schema.yaml
+++ b/rime_frost_double_pinyin_mspy.schema.yaml
@@ -302,7 +302,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的
 
 

--- a/rime_frost_double_pinyin_sogou.schema.yaml
+++ b/rime_frost_double_pinyin_sogou.schema.yaml
@@ -302,7 +302,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的
 
 

--- a/rime_frost_double_pinyin_ziguang.schema.yaml
+++ b/rime_frost_double_pinyin_ziguang.schema.yaml
@@ -300,7 +300,7 @@ recognizer:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
-  search: "`"             # 辅码引导符，要添加到 speller/alphabet
+  aux_code_trigger: "`"   # 辅码引导符，要添加到 speller/alphabet
   # bindings:             # 也可以再增加方案专有的
 
 


### PR DESCRIPTION
方案中使用 `key_binder/search` 指定辅助码引导符，但实际上处理辅助码的 Lua 脚本读取的引导符配置名为 `key_binder/aux_code_trigger`，使用 `key_binder/search` 配置引导符是没用的。 因此更正引导符配置名称为 `key_binder/aux_code_trigger`，与脚本保持一致。