### PR TITLE
修复英文扩展词表因分隔符错误导致的构建失败

### DIFF
--- a/en_dicts/en_ext.dict.yaml
+++ b/en_dicts/en_ext.dict.yaml
@@ -153,7 +153,7 @@ iPhone 17	iPhone	4
 iPhone 17 Plus	iPhone	3
 iPhone 17 Pro	iPhone	2
 iPhone 17 Pro Max	iPhone	1
-iPhone Air iPhone 1
+iPhone Air	iPhone	1
 
 Mac OS X	MacOSX	999
 Mac OS X Cheetah	MacOSX	1
@@ -180,7 +180,7 @@ macOS Big Sur	macOS	5
 macOS Monterey	macOS	6
 macOS Ventura	macOS	7
 macOS Sonoma	macOS	8
-macOS Tahoe  macOS 9
+macOS Tahoe	macOS	9
 
 Windows	Windows	999
 Windows 95	Windows	1
@@ -561,7 +561,7 @@ SQLite	SQLite
 Sourcetree	Sourcetree
 Spiritfarer	Spiritfarer
 TCP/IP	TCP/IP
-Turso  Turso
+Turso	Turso
 Twitter	Twitter
 V2EX	V2EX
 VSCode	VSCode
@@ -747,7 +747,7 @@ Mac App Store	MacAppStore
 Mac Rumors	MacRumors
 MacAppDeals	MacAppDeals
 MacBook	MacBook
-MacBook Neo MacBook Neo
+MacBook Neo	MacBookNeo
 MacBook Air	MacBookAir
 MacBook Pro	MacBookPro
 Mac Pro	MacPro


### PR DESCRIPTION
在近期词库构建过程中，发现 `en_dicts/en_ext.dict.yaml` 中部分新增词条错误地使用了空格（Space）作为字段分隔符，而 Rime 词典格式要求使用制表符（Tab `\t`）分隔“词条”、“编码”和“权重”等字段。

对于包含空格的多词短语（如 `iPhone Air`、`MacBook Neo`、`macOS Tahoe` 等），解析器无法正确识别字段边界，导致整行内容被错误解析，最终触发 `entry_collector.cc` 的编码校验异常并导致构建失败。

本 PR 将相关词条中的错误分隔符统一修正为标准 Tab 分隔符，恢复词表正常解析与编译。

相关报错日志如下：

```text
E20260610 08:51:56.875749 140265815383680 entry_collector.cc:139] Encode failure: 'iPhone Air iPhone 1'.
E20260610 08:51:56.875836 140265815383680 entry_collector.cc:139] Encode failure: 'macOS Tahoe  macOS 9'.
E20260610 08:51:56.875850 140265815383680 entry_collector.cc:139] Encode failure: 'Turso  Turso'.
E20260610 08:51:56.875879 140265815383680 entry_collector.cc:139] Encode failure: 'MacBook Neo MacBook Neo'.
```
