### PR TITLE
修复 Star History 图失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ kenlm 教程、python 调用 <https://github.com/mattzheng/py-kenlm-model>
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=gaboolic/rime-frost&type=Date)](https://star-history.com/#gaboolic/rime-frost&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=gaboolic/rime-frost&type=Date)](https://star-history.dera.page/#gaboolic/rime-frost&Date)


### PR DESCRIPTION
仓库 README 中的 Star History 图目前无法正常显示，因为原有的数据接口受到 GitHub 限制。

此改动将图表切换到可正常工作的地址，恢复 Star 历史图表的展示。感谢您的理解与支持。