### PR TITLE
feat(dict): add hot words 特努斯

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -614,3 +614,5 @@ sort: by_weight
 起号	qi hao	0
 歌川国芳	ge chuan guo fang	0
 抢客	qiang ke	0
+# 2026-09-02 新增：热榜新词/专名（来自 zhihu_missing_2026-09-02 分词缺失词）
+特努斯	te nu si	0


### PR DESCRIPTION
- 新增 1 词至 cn_dicts/others.dict.yaml:618，来源 zhihu_missing_2026-09-02 分词缺失词
- 热词：特努斯（Apple 硬件工程负责人 John Ternus，见 2026-09-02 热榜「库克卸任由特努斯接棒」）
- 频率统一为 0，基于最新 master，仅含词库变更