### PR TITLE
feat(dict): add hot words 季洁/敖白/常威/矿潮/仲树等 (2026-09-05)

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -631,3 +631,21 @@ sort: by_weight
 王义为	wang yi wei	0
 白牌	bai pai	0
 钝化工艺	dun hua gong yi	0
+# 2026-09-05 新增：热榜新词/角色名/专名（来自 zhihu_missing_2026-09-05 分词缺失词）
+季洁	ji jie	0
+敖白	ao bai	0
+常威	chang wei	0
+矿潮	kuang chao	0
+仲树	zhong shu	0
+九斤	jiu jin	0
+接尿	jie niao	0
+罗维	luo wei	0
+花臂	hua bi	0
+刘洵	liu xun	0
+宗生	zong sheng	0
+王茜	wang qian	0
+矿卡	kuang ka	0
+鸡仔	ji zai	0
+卢虹贝	lu hong bei	0
+步亭	bu ting	0
+猴侠	hou xia	0


### PR DESCRIPTION
- 来源: data/corpus/zhihu_missing_2026-09-05.txt (55 缺失, 98.75% 覆盖)
- 新增 17 词: 季洁/敖白/常威/矿潮/仲树/九斤/接尿/罗维/花臂/刘洵/宗生/王茜/矿卡/鸡仔/卢虹贝/步亭/猴侠
- 跳过分词碎片: 切全/中喊/之刀/仲树式/会塌等 38 项

Refs: zhihu hotlist 2026-09-05 (30 items, 90KB, playwright full body)