### PR TITLE
feat(dict): add hot words 加朵/二壮/访存/位线等 (2026-09-06)

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -649,3 +649,24 @@ sort: by_weight
 卢虹贝	lu hong bei	0
 步亭	bu ting	0
 猴侠	hou xia	0
+# 2026-09-06 新增：热榜新词/专名/技术术语（来自 zhihu_missing_2026-09-06 分词缺失词）
+加朵	jia duo	0
+二壮	er zhuang	0
+访存	fang cun	0
+位线	wei xian	0
+派蒂	pai di	0
+涉师	she shi	0
+硕蠊	shuo lian	0
+超调	chao tiao	0
+三贼	san zei	0
+吕家篇	lv jia pian	0
+回破	hui po	0
+恋陪	lian pei	0
+林禄	lin lu	0
+柳坤生	liu kun sheng	0
+残涡	can wo	0
+泰思妥	tai si tuo	0
+浙闽	zhe min	0
+牛河	niu he	0
+老肖	lao xiao	0
+育囊	yu nang	0


### PR DESCRIPTION
- 来源: data/corpus/zhihu_missing_2026-09-06.txt (66 缺失, 98.59% 覆盖)
- 新增 20 词: 加朵/二壮/访存/位线/派蒂/涉师/硕蠊/超调/三贼/吕家篇/回破/恋陪/林禄/柳坤生/残涡/泰思妥/浙闽/牛河/老肖/育囊
- 跳过分词碎片: 曲彤/沙德尔（已收录）/放二壮/派导/二贼/亲职/会判/全挤等 46 项

Refs: zhihu hotlist 2026-09-06 (30 items, 104KB, playwright full body)