### PR TITLE
feat(dict): add hot words 默茨/亲欧/夏窗/硅脑等 (2026-09-07)

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -670,3 +670,18 @@ sort: by_weight
 牛河	niu he	0
 老肖	lao xiao	0
 育囊	yu nang	0
+# 2026-09-07 新增：热榜新词/专名/技术术语（来自 zhihu_missing_2026-09-07 分词缺失词）
+默茨	mo ci	0
+湿擦	shi ca	0
+亲欧	qin ou	0
+压胜	ya sheng	0
+吉伯	ji bo	0
+夏窗	xia chuang	0
+硅脑	gui nao	0
+票型	piao xing	0
+选制	xuan zhi	0
+采销	cai xiao	0
+首锅	shou guo	0
+老圣迷	lao sheng mi	0
+芙琳	fu lin	0
+帝景	di jing	0


### PR DESCRIPTION
- 来源: data/corpus/zhihu_missing_2026-09-07.txt (44 缺失, 98.54% 覆盖)
- 新增 14 词: 默茨/湿擦/亲欧/压胜/吉伯/夏窗/硅脑/票型/选制/采销/首锅/老圣迷/芙琳/帝景
- 跳过分词碎片: 中老/以子/光个/党大/剪藤/升个/卖金/卡去/名包/因该/嫌窝/应像/开掉/旅过/景是/条里/树主/样章/狗修/率服/王之师/男田/而王/聘有/裸着/观已/训到/这鱼/里排/骚情 等 30 项（古典引文碎片/动词短语/错误切分）

Refs: zhihu hotlist 2026-09-07 (30 items, 66KB, playwright full body)