### PR TITLE
feat(dict): add hot words 石兽/乘联 (2026-09-08)

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -685,3 +685,6 @@ sort: by_weight
 老圣迷	lao sheng mi	0
 芙琳	fu lin	0
 帝景	di jing	0
+# 2026-09-08 新增：热榜新词/专名（来自 zhihu_missing_2026-09-08 分词缺失词）
+石兽	shi shou	0
+乘联	cheng lian	0


### PR DESCRIPTION
- 来源: data/corpus/zhihu_missing_2026-09-08.txt (8 缺失, 98.35% 覆盖)
- 新增 2 词: 石兽/乘联
- 跳过分词碎片: 且许/入江/卸空后/扶上/放姜/早入 等 6 项（动词短语/方位短语/错误切分：且许=且+许晴碎片；入江=动词+名词短语；卸空后=动词+时间后缀；扶上=动宾短语；放姜=动宾短语；早入=副词+动词短语）

Refs: zhihu hotlist 2026-09-08 (30 items, 10KB, excerpt only, --skip-hot)