### PR TITLE
feat(dict): 坏菜/沙嗲/去冰微糖/去冰/微糖 & 爪牙 zhua ya (2026-09-10 补)

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -717,3 +717,10 @@ sort: by_weight
 喂球	wei qiu	0
 穿裆	chuan dang	0
 阔出	kuo chu	0
+# 2026-09-10 补：奶茶去冰微糖/口语 & 爪牙多音（用户指定）
+坏菜	huai cai	0
+沙嗲	sha die	0
+去冰微糖	qu bing wei tang	0
+去冰	qu bing	0
+微糖	wei tang	0
+爪牙	zhua ya	0


### PR DESCRIPTION
- 新增 6 词: 坏菜/沙嗲/去冰微糖/去冰/微糖/爪牙\n- 坏菜 huai cai 0, 沙嗲 sha die 0, 去冰微糖 qu bing wei tang 0, 去冰 qu bing 0, 微糖 wei tang 0, 爪牙 zhua ya 0 (补 zhao ya 之外的读音)\n- 来源: 用户指定, 奶茶自定义口语\n\nRefs: #310