### PR TITLE
feat(dict): 跍蹲/圪蹴 (gu dun/ge jiu) (2026-09-10 补2)

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -724,3 +724,6 @@ sort: by_weight
 去冰	qu bing	0
 微糖	wei tang	0
 爪牙	zhua ya	0
+# 2026-09-10 补2：方言蹲姿（用户指定）
+跍蹲	gu dun	0
+圪蹴	ge jiu	0


### PR DESCRIPTION
- 新增 2 词: 跍蹲 gu dun 0, 圪蹴 ge jiu 0\n- 方言蹲姿, base.dict 中为注释态 (#圪蹴 ge jiu), 此处补为可用词\n- 频率 0\n\nRefs: 用户指定